### PR TITLE
fix dfree smb error

### DIFF
--- a/files/board/arpl/overlayfs/etc/samba/smb.conf
+++ b/files/board/arpl/overlayfs/etc/samba/smb.conf
@@ -4,6 +4,8 @@
   obey pam restrictions = yes
   map to guest = Bad User
   usershare allow guests = yes
+  dfree command = /usr/bin/df
+
 [arpl]
   browseable = yes
   public = yes


### PR DESCRIPTION
ISSUE:
When trying to send file to arpl samba share from windows OS, you got error "not enough free space on storage"!
In log/var/log/samba/log.smbd
-->../../source3/smbd/dfree.c:166(sys_disk_free) WARNING: dfree is broken on this system

Samba tries to use command dfree which does not exist on this system.

To FIX:
Just say samba to use "df" command
